### PR TITLE
addproducts.md: Fix types

### DIFF
--- a/docs/api/business_api/baseoperation/addproducts.md
+++ b/docs/api/business_api/baseoperation/addproducts.md
@@ -14,7 +14,7 @@ $outputGetBasket = $this->getBusinessApi()->call('basket.get_basket', $inputGetB
 $outputGetBasket->basket->clearAllMessages();
 $itemData = new ItemData(
     array(
-        'quantity'    => 1,
+        'quantity'    => '1',
         'isVariant'   => false,
         'variantCode' =>  '',
         'sku'         => '1000',

--- a/docs/api/business_api/baseoperation/addproducts.md
+++ b/docs/api/business_api/baseoperation/addproducts.md
@@ -15,7 +15,7 @@ $outputGetBasket->basket->clearAllMessages();
 $itemData = new ItemData(
     array(
         'quantity'    => '1',
-        'isVariant'   => false,
+        'isVariant'   => '',
         'variantCode' =>  '',
         'sku'         => '1000',
     )


### PR DESCRIPTION
The [`AddItem:: checkProperties`](https://github.com/ezsystems/ezcommerce-shop/blob/v3.1.3/src/Silversolutions/Bundle/EshopBundle/Entities/BusinessLayer/InputValueObjects/AddItemToBasket/ItemData.php#L52) property claims some counter intuitive types for `quantity` and `isVariant`. The documentation could help to avoid those traps.

Note: `numeric` and `boolean` are supported by [`ValueObject:: validateProperties`](https://github.com/ezsystems/ezcommerce-shop/blob/v3.1.3/src/Silversolutions/Bundle/EshopBundle/Content/ValueObject.php#L171), so, code itself should be enhanced
instead of documentation but it might be harder due to side effects.
