### PR TITLE
Explain `InputAddItemToBasket` and `OutputAddItemToBasket` aliases

### DIFF
--- a/docs/api/business_api/businessapi_invocation_service.md
+++ b/docs/api/business_api/businessapi_invocation_service.md
@@ -76,6 +76,9 @@ For example:
 ``` php
 namespace Example\Bundle\ExtensionBundle\Services\BusinessLayer\Operations;
 
+use Silversolutions\Bundle\EshopBundle\Entities\BusinessLayer\InputValueObjects\AddItemToBasket as InputAddItemToBasket;
+use Silversolutions\Bundle\EshopBundle\Entities\BusinessLayer\OutputValueObjects\AddItemToBasket as OutputAddItemToBasket;
+
 class NewBasketApi extends Silversolutions\Bundle\EshopBundle\Services\BusinessLayer\Operations\Basket
 {
     public function newBasketOperation(InputBasketOperation $operationInput) {


### PR DESCRIPTION
`InputAddItemToBasket` and `OutputAddItemToBasket` aliases are used in several documentation pages but the real classes were not clearly exposed.